### PR TITLE
chore: update to use public `pythonbible` package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "ask-sdk-core>=1.19.0,<2.0.0",
     "uuid6>=2025.0.1",
     "numpy>=2.3.2,<3.0.0",
-    "pythonbible @ https://github.com/jirehhuang/pythonbible-lite/archive/39ce5eb3331715458ab2a1c9c4a85ef5d12d7542.tar.gz",
+    "pythonbible>=0.15.0,<0.16.0",
 ]
 
 [tool.poetry]


### PR DESCRIPTION
Because `pythonbible-lite` is no longer necessary as of `pythonbible` v0.15.1 (see [archival note in README](https://github.com/jirehhuang/pythonbible-lite)).